### PR TITLE
Fix build errors for Flipper Zero 0.82 firmware

### DIFF
--- a/spectrum_analyzer/spectrum_analyzer.c
+++ b/spectrum_analyzer/spectrum_analyzer.c
@@ -326,7 +326,7 @@ void spectrum_analyzer_calculate_frequencies(SpectrumAnalyzerModel* model) {
     model->max_rssi = -200.0;
     model->max_rssi_dec = 0;
 
-    FURI_LOG_D("Spectrum", "setup_frequencies - max_hz: %u - min_hz: %u", max_hz, min_hz);
+    FURI_LOG_D("Spectrum", "setup_frequencies - max_hz: %ld - min_hz: %ld", max_hz, min_hz);
     FURI_LOG_D("Spectrum", "center_freq: %u", model->center_freq);
     FURI_LOG_D(
         "Spectrum",
@@ -450,7 +450,7 @@ int32_t spectrum_analyzer_app(void* p) {
             break;
         case InputKeyRight:
             model->center_freq += hstep;
-            FURI_LOG_D("Spectrum", "center_freq: %lu", model->center_freq);
+            FURI_LOG_D("Spectrum", "center_freq: %d", model->center_freq);
             spectrum_analyzer_calculate_frequencies(model);
             spectrum_analyzer_worker_set_frequencies(
                 spectrum_analyzer->worker, model->channel0_frequency, model->spacing, model->width);
@@ -460,7 +460,9 @@ int32_t spectrum_analyzer_app(void* p) {
             spectrum_analyzer_calculate_frequencies(model);
             spectrum_analyzer_worker_set_frequencies(
                 spectrum_analyzer->worker, model->channel0_frequency, model->spacing, model->width);
-            FURI_LOG_D("Spectrum", "center_freq: %lu", model->center_freq);
+            FURI_LOG_D("Spectrum", "center_freq: %d", model->center_freq);
+            break;
+        default:
             break;
         case InputKeyOk: {
             switch(model->width) {

--- a/spectrum_analyzer/spectrum_analyzer_worker.c
+++ b/spectrum_analyzer/spectrum_analyzer_worker.c
@@ -168,7 +168,7 @@ void spectrum_analyzer_worker_set_frequencies(
 
     FURI_LOG_D(
         "SpectrumWorker",
-        "spectrum_analyzer_worker_set_frequencies - channel0_frequency= %u - spacing = %u - width = %u",
+        "spectrum_analyzer_worker_set_frequencies - channel0_frequency= %lu - spacing = %lu - width = %u",
         channel0_frequency,
         spacing,
         width);


### PR DESCRIPTION
Add default case for switch statement and fix printf-style type specifier mismatches.